### PR TITLE
MULE-16417: Fix issues affecting mule-aggregators-module tests on Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
         <muleVmConnectorTestVersion>1.1.0</muleVmConnectorTestVersion>
         <javaXmlBindApiVersion>2.3.1</javaXmlBindApiVersion>
         <javaXmlBindVersion>2.3.1</javaXmlBindVersion>
-        <javaActivationVersion>1.1.1</javaActivationVersion>
         <istackCommonsRuntimeVersion>2.24</istackCommonsRuntimeVersion>
         <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>
     </properties>
@@ -64,12 +63,6 @@
             <artifactId>mule-vm-connector</artifactId>
             <version>${muleVmConnectorTestVersion}</version>
             <classifier>mule-plugin</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>${javax.activation.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,11 @@
         <muleFileConnectorTestVersion>1.2.1</muleFileConnectorTestVersion>
         <muleTestsComponentPlugin>4.1.5</muleTestsComponentPlugin>
         <muleVmConnectorTestVersion>1.1.0</muleVmConnectorTestVersion>
+        <javaXmlBindApiVersion>2.3.1</javaXmlBindApiVersion>
+        <javaXmlBindVersion>2.3.1</javaXmlBindVersion>
+        <javaActivationVersion>1.1.1</javaActivationVersion>
+        <istackCommonsRuntimeVersion>2.24</istackCommonsRuntimeVersion>
+        <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>
     </properties>
 
     <dependencies>
@@ -60,6 +65,33 @@
             <version>${muleVmConnectorTestVersion}</version>
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>${javax.activation.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${javaXmlBindApiVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>${javaXmlBindVersion}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.stream</groupId>
+                    <artifactId>stax-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.istack</groupId>
+            <artifactId>istack-commons-runtime</artifactId>
+            <version>${istackCommonsRuntimeVersion}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,6 @@
         <muleFileConnectorTestVersion>1.2.1</muleFileConnectorTestVersion>
         <muleTestsComponentPlugin>4.1.5</muleTestsComponentPlugin>
         <muleVmConnectorTestVersion>1.1.0</muleVmConnectorTestVersion>
-        <javaXmlBindApiVersion>2.3.1</javaXmlBindApiVersion>
-        <javaXmlBindVersion>2.3.1</javaXmlBindVersion>
-        <istackCommonsRuntimeVersion>2.24</istackCommonsRuntimeVersion>
         <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>
     </properties>
 
@@ -64,27 +61,6 @@
             <version>${muleVmConnectorTestVersion}</version>
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>${javaXmlBindApiVersion}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>${javaXmlBindVersion}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.xml.stream</groupId>
-                    <artifactId>stax-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.istack</groupId>
-            <artifactId>istack-commons-runtime</artifactId>
-            <version>${istackCommonsRuntimeVersion}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Adding missing dependencies for Java EE modules that were removed on
 JDK 11
 - Take into account that these tests won't fully work until
 `mule-core-modules-parent` gets updated to the next minor version
 `1.2.0` and the packages corresponding to these removed modules get
 added to the classloader boot packages list