### PR TITLE
AMOD-2: fix aggregator inside scatter-gather not working properly

### DIFF
--- a/src/main/java/org/mule/extension/aggregator/internal/storage/content/SimpleAggregatedContent.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/content/SimpleAggregatedContent.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public class SimpleAggregatedContent extends AbstractAggregatedContent {
 
   private static final long serialVersionUID = -229638907750317297L;
-  private Map<Integer, TypedValue> sequencedElements;
+  private Map<Integer, List<TypedValue>> sequencedElements;
   private List<TypedValue> unsequencedElements;
 
   private SimpleAggregatedContent() {
@@ -53,7 +53,15 @@ public class SimpleAggregatedContent extends AbstractAggregatedContent {
 
   @Override
   public void add(TypedValue newContent, Long timeStamp, int sequenceNumber) {
-    sequencedElements.put(sequenceNumber, newContent);
+    if (sequencedElements.containsKey(sequenceNumber)) {
+      sequencedElements.get(sequenceNumber).add(newContent);
+    } else {
+      List<TypedValue> newList = new ArrayList<>();
+      newList.add(newContent);
+      sequencedElements.put(sequenceNumber, newList);
+    }
+
+    //sequencedElements.put(sequenceNumber, newContent);
     updateTimes(timeStamp);
   }
 
@@ -61,7 +69,8 @@ public class SimpleAggregatedContent extends AbstractAggregatedContent {
   public List<TypedValue> getAggregatedElements() {
     List<TypedValue> orderedElements = new ArrayList<>();
     if (sequencedElements.size() > 0) {
-      orderedElements = sequencedElements.entrySet().stream().sorted(comparingInt(Map.Entry::getKey)).map(Map.Entry::getValue)
+      orderedElements = sequencedElements.entrySet().stream().sorted(comparingInt(Map.Entry::getKey))
+          .flatMap(val -> val.getValue().stream())
           .collect(toList());
     }
     orderedElements.addAll(unsequencedElements);

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/content/SimpleAggregatedContent.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/content/SimpleAggregatedContent.java
@@ -61,7 +61,6 @@ public class SimpleAggregatedContent extends AbstractAggregatedContent {
       sequencedElements.put(sequenceNumber, newList);
     }
 
-    //sequencedElements.put(sequenceNumber, newContent);
     updateTimes(timeStamp);
   }
 

--- a/src/test/munit/aggregators-scenarios-test-case.xml
+++ b/src/test/munit/aggregators-scenarios-test-case.xml
@@ -181,6 +181,63 @@
         <munit-tools:queue/>
     </flow>
 
+    <munit:test name="testTimeBasedAggregationWithSequenceNumber"
+                tags="Aggregators Extension,Integration Tests"
+                description="Verify the time based aggregator with sequence number">
+        <munit:enable-flow-sources>
+            <munit:enable-flow-source value="flightOrdersAggregatorSeqListenerFlow"/>
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <file:read config-ref="fileConfig" path="#['input' ++ p('file.separator') ++ 'flight-orders.json']"/>
+
+            <foreach>
+                <scatter-gather>
+                    <route>
+                        <aggregators:time-based-aggregator period="${timeBasedAggregatorTimeout}" name="flightOrdersAggregatorSeq">
+                            <aggregators:content><![CDATA[#[%dw 2.0 output application/json --- payload]]]></aggregators:content>
+                            <aggregators:incremental-aggregation>
+                                <logger level="INFO" message="Flight order aggregated."/>
+                            </aggregators:incremental-aggregation>
+                        </aggregators:time-based-aggregator>
+                    </route>
+                    <route>
+                        <logger level="INFO" message="Flight order aggregated."/>
+                    </route>
+                </scatter-gather>
+                <choice>
+                    <when expression="#[(vars.counter mod 2) == 0]">
+                        <munit-tools:sleep time="${timeBasedAggregatorTimeoutSleep}" timeUnit="SECONDS"/>
+                    </when>
+                </choice>
+            </foreach>
+        </munit:execution>
+        <munit:validation>
+            <!-- Build the list of the expected flight aggregations to be performed by the app -->
+            <file:read config-ref="fileConfig" path="input/flight-orders.json"
+                       target="expectedAggregations"
+                       targetValue="#[%dw 2.0 import * from dw::core::Arrays --- payload divideBy ${aggregatorsSize}]"/>
+
+            <!-- Consume message of processed flight orders -->
+            <munit-tools:dequeue target="actualAggregations"
+                                 targetValue="#[%dw 2.0 output application/json --- payload orderBy($.date)]"/>
+
+            <munit-tools:assert-that expression="#[vars.actualAggregations]" is="#[MunitTools::equalTo(vars.expectedAggregations[0] orderBy($.date))]"/>
+
+            <!-- Consume message of processed flight orders -->
+            <munit-tools:dequeue target="actualAggregations"
+                                 targetValue="#[%dw 2.0 output application/json --- payload orderBy($.date)]"/>
+
+            <munit-tools:assert-that expression="#[vars.actualAggregations]" is="#[MunitTools::equalTo(vars.expectedAggregations[1] orderBy($.date))]"/>
+        </munit:validation>
+    </munit:test>
+
+    <flow name="flightOrdersAggregatorSeqListenerFlow">
+        <aggregators:aggregator-listener aggregatorName="flightOrdersAggregatorSeq"/>
+
+        <!-- Send flight orders to message queue -->
+        <munit-tools:queue/>
+    </flow>
+
     <!--  -->
     <!-- Migrated from mule-ee-distributions -->
     <!-- https://github.com/mulesoft/mule-ee-distributions/blob/eebf8f83189a0666bc5e36da849aa4c0c0e41fa1/tests/src/test/java/com/mulesoft/mule/distributions/server/integration/scenarios/AggregatorsScenariosTestCase.java#L267 -->

--- a/src/test/munit/aggregators-scenarios-test-case.xml
+++ b/src/test/munit/aggregators-scenarios-test-case.xml
@@ -181,11 +181,11 @@
         <munit-tools:queue/>
     </flow>
 
-    <munit:test name="testTimeBasedAggregationWithSequenceNumber"
+    <munit:test name="testTimeBasedAggregationInsideScatterGather"
                 tags="Aggregators Extension,Integration Tests"
-                description="Verify the time based aggregator with sequence number">
+                description="Verify the time based aggregator inside scatther-gather flow">
         <munit:enable-flow-sources>
-            <munit:enable-flow-source value="flightOrdersAggregatorSeqListenerFlow"/>
+            <munit:enable-flow-source value="flightOrdersAggregatorScatterListenerFlow"/>
         </munit:enable-flow-sources>
         <munit:execution>
             <file:read config-ref="fileConfig" path="#['input' ++ p('file.separator') ++ 'flight-orders.json']"/>
@@ -193,7 +193,7 @@
             <foreach>
                 <scatter-gather>
                     <route>
-                        <aggregators:time-based-aggregator period="${timeBasedAggregatorTimeout}" name="flightOrdersAggregatorSeq">
+                        <aggregators:time-based-aggregator period="${timeBasedAggregatorTimeout}" name="flightOrdersAggregatorScatter">
                             <aggregators:content><![CDATA[#[%dw 2.0 output application/json --- payload]]]></aggregators:content>
                             <aggregators:incremental-aggregation>
                                 <logger level="INFO" message="Flight order aggregated."/>
@@ -231,8 +231,8 @@
         </munit:validation>
     </munit:test>
 
-    <flow name="flightOrdersAggregatorSeqListenerFlow">
-        <aggregators:aggregator-listener aggregatorName="flightOrdersAggregatorSeq"/>
+    <flow name="flightOrdersAggregatorScatterListenerFlow">
+        <aggregators:aggregator-listener aggregatorName="flightOrdersAggregatorScatter"/>
 
         <!-- Send flight orders to message queue -->
         <munit-tools:queue/>


### PR DESCRIPTION
When using an aggregator module, the result is different if the event comes from a scatter-gather or not.
This happens because the event is different when it goes through a scatter-gather because it adds the itemSequenceInfo attribute.

The problem arises when the aggregator receives an itemSequenceInfo as an attribute. Because what it does is differentiate if it has to add the new element in the sequencedElements (a HashMap) or in unsequencedElements (a List). When it uses the list it works as expected but when it uses the map it doesn't.

The scatter-gather uses the itemSequenceInfo attribute to save info such as the position of each subflow but the aggregator uses the value of the position that is inside the itemSequenceInfo as a sequence number (key of sequencedElements) which in the case of coming from the scatter is always the same (pos 1, for example). So it always replace the value on the map and the result is that the aggregator does not aggregate the calls when it comes from the scatter-gather and always returns only the last element.

The tentative solution is that each value of sequencedElements is a list instead of a single element. In order to add elements for each sequence number and return the different lists as a single list grouped and sorted by their sequence number.
