### PR TITLE
AMOD-5: Fix messages getting lost in group based aggregator and when using sequence number id

### DIFF
--- a/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/AbstractAggregatorExecutor.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/AbstractAggregatorExecutor.java
@@ -200,6 +200,7 @@ public abstract class AbstractAggregatorExecutor
     if (clusterService.isPrimaryPollingInstance()) {
       if (!started) {
         startIfNeeded(objectStore);
+        upgradeAggregatedContentIfNeeded();
         setRegisteredAsyncAggregationsAsNotScheduled();
         if (getStorage().isPersistent()) {
           scheduler = schedulerService.ioScheduler(SchedulerConfig.config().withShutdownTimeout(0, MILLISECONDS));
@@ -385,4 +386,11 @@ public abstract class AbstractAggregatorExecutor
     }
   }
 
+  /**
+   * This method upgrades the sequenced elements to the new data structure for backward compatibility.
+   * TODO: fix this AMOD-5. This should be removed in the next major release.
+   */
+  private void upgradeAggregatedContentIfNeeded() {
+    executeSynchronized(() -> sharedInfoLocalCopy.upgradeIfNeeded());
+  }
 }

--- a/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/AbstractAggregatorExecutor.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/AbstractAggregatorExecutor.java
@@ -386,9 +386,9 @@ public abstract class AbstractAggregatorExecutor
     }
   }
 
+  // TODO: fix this AMOD-5. This should be removed in the next major release.
   /**
    * This method upgrades the sequenced elements to the new data structure for backward compatibility.
-   * TODO: fix this AMOD-5. This should be removed in the next major release.
    */
   @Deprecated
   private void upgradeAggregatedContentIfNeeded() {

--- a/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/AbstractAggregatorExecutor.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/AbstractAggregatorExecutor.java
@@ -390,6 +390,7 @@ public abstract class AbstractAggregatorExecutor
    * This method upgrades the sequenced elements to the new data structure for backward compatibility.
    * TODO: fix this AMOD-5. This should be removed in the next major release.
    */
+  @Deprecated
   private void upgradeAggregatedContentIfNeeded() {
     executeSynchronized(() -> sharedInfoLocalCopy.upgradeIfNeeded());
   }

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/content/AggregatedContent.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/content/AggregatedContent.java
@@ -59,9 +59,9 @@ public interface AggregatedContent extends Serializable {
    */
   public boolean isComplete();
 
+  // TODO: fix this AMOD-5. This should be removed in the next major release.
   /**
    * This method upgrades the sequenced elements to the new data structure for backward compatibility.
-   * TODO: fix this AMOD-5. This should be removed in the next major release.
    */
   @Deprecated
   public void upgradeIfNeeded();

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/content/AggregatedContent.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/content/AggregatedContent.java
@@ -59,4 +59,11 @@ public interface AggregatedContent extends Serializable {
    */
   public boolean isComplete();
 
+  /**
+   * This method upgrades the sequenced elements to the new data structure for backward compatibility.
+   * TODO: fix this AMOD-5. This should be removed in the next major release.
+   */
+  @Deprecated
+  public void upgradeIfNeeded();
+
 }

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/content/SimpleAggregatedContent.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/content/SimpleAggregatedContent.java
@@ -91,9 +91,9 @@ public class SimpleAggregatedContent extends AbstractAggregatedContent {
     return maxSize == unsequencedElements.size() + sequencedElementsSize;
   }
 
+  // TODO: fix this AMOD-5. This should be removed in the next major release.
   /**
    * This method upgrades the sequenced elements to the new data structure for backward compatibility.
-   * TODO: fix this AMOD-5. This should be removed in the next major release.
    */
   @Deprecated
   public void upgradeIfNeeded() {
@@ -116,9 +116,9 @@ public class SimpleAggregatedContent extends AbstractAggregatedContent {
     }
   }
 
+  // TODO: fix this AMOD-5. This should be removed in the next major release.
   /**
    * Inner class to save a list instead of a single element when aggregating elements by sequence number.
-   * TODO: fix this AMOD-5. This should be removed in the next major release.
    */
   @Deprecated
   private static class SequencedElement implements Serializable {

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/content/SimpleAggregatedContent.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/content/SimpleAggregatedContent.java
@@ -6,15 +6,18 @@
  */
 package org.mule.extension.aggregator.internal.storage.content;
 
-import static java.util.Comparator.comparingInt;
 import static java.util.stream.Collectors.toList;
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.mule.runtime.api.metadata.TypedValue;
+import org.slf4j.Logger;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 
 /**
@@ -24,13 +27,13 @@ import java.util.Map;
  */
 public class SimpleAggregatedContent extends AbstractAggregatedContent {
 
-  private static final long serialVersionUID = -229638907750317297L;
-  private Map<Integer, TypedValue> sequencedElements;
-  private List<TypedValue> unsequencedElements;
+  private static final Logger LOGGER = getLogger(SimpleAggregatedContent.class);
+  private static final long serialVersionUID = -6742302221567847200L;
+
+  private Map<Index, TypedValue> indexedElements;
 
   private SimpleAggregatedContent() {
-    this.sequencedElements = new HashMap<>();
-    this.unsequencedElements = new ArrayList<>();
+    this.indexedElements = new HashMap<>();
   }
 
   public SimpleAggregatedContent(int maxSize) {
@@ -47,44 +50,46 @@ public class SimpleAggregatedContent extends AbstractAggregatedContent {
 
   @Override
   public void add(TypedValue newContent, Long timeStamp) {
-    unsequencedElements.add(newContent);
+    indexedElements.put(lastArrivalIndex(null), newContent);
     updateTimes(timeStamp);
   }
 
   @Override
   public void add(TypedValue newContent, Long timeStamp, int sequenceNumber) {
-    sequencedElements.put(sequenceNumber, newContent);
+    indexedElements.put(lastArrivalIndex(sequenceNumber), newContent);
     updateTimes(timeStamp);
   }
 
   @Override
   public List<TypedValue> getAggregatedElements() {
-    List<TypedValue> orderedElements = new ArrayList<>();
-    if (sequencedElements.size() > 0) {
-      orderedElements = sequencedElements.entrySet().stream().sorted(comparingInt(Map.Entry::getKey)).map(Map.Entry::getValue)
-          .collect(toList());
+    if (indexedElements.isEmpty()) {
+      return Collections.emptyList();
     }
-    orderedElements.addAll(unsequencedElements);
-    return orderedElements;
+    return indexedElements.entrySet().stream().sorted((e1, e2) -> e1.getKey().compareTo(e2.getKey()))
+        .map(Map.Entry::getValue)
+        .collect(toList());
   }
-
 
   public boolean isComplete() {
-    return maxSize == sequencedElements.size() + unsequencedElements.size();
+    return maxSize == indexedElements.size();
   }
 
-  private static class Index implements Serializable {
+  private Index lastArrivalIndex(Integer key) {
+    Index index = new Index(0, key);
+    while (indexedElements.containsKey(index)) {
+      index.forwardArrival();
+    }
+    return index;
+  }
 
-    private static final long serialVersionUID = -8286760373914606346L;
+  private static class Index implements Serializable, Comparable {
+
+    private static final long serialVersionUID = 7902763275773976860L;
     private Integer sequenceNumber = null;
     private int arrivalIndex = 0;
 
-    public Index(int arrivalIndex) {
+    public Index(int arrivalIndex, Integer sequenceNumber) {
       this.arrivalIndex = arrivalIndex;
-    }
-
-    public Index(int arrivalIndex, int sequenceNumber) {
-      this(arrivalIndex);
       this.sequenceNumber = sequenceNumber;
     }
 
@@ -95,6 +100,60 @@ public class SimpleAggregatedContent extends AbstractAggregatedContent {
     public int getArrivalIndex() {
       return arrivalIndex;
     }
-  }
 
+    /**
+     * Compares this index with the specified index for order. Returns a negative integer, zero, or a positive integer
+     * as this object is less than, equal to, or greater than the specified index. It is first compared by the sequence
+     * number and then by the arrival number.
+     *
+     * @param o the index to compare to. It cannot be null.
+     *
+     * @return a negative integer, zero, or a positive integer as this index is less than, equal to, or greater than the
+     * specified index.
+     */
+    @Override
+    public int compareTo(Object o) {
+      if (Objects.isNull(o) || !(o instanceof Index)) {
+        throw new RuntimeException("The specified object is not an instance of Index");
+      }
+      Index otherIndex = (Index) o;
+      int sequenceComparison = compareSequence(otherIndex);
+      if (sequenceComparison != 0) {
+        return sequenceComparison;
+      }
+      return Integer.compare(arrivalIndex, otherIndex.getArrivalIndex());
+    }
+
+    public void forwardArrival() {
+      arrivalIndex++;
+    }
+
+    private int compareSequence(Index otherIndex) {
+      if (Objects.isNull(sequenceNumber) && Objects.isNull(otherIndex.getSequenceNumber())) {
+        return 0;
+      }
+      if (!Objects.isNull(sequenceNumber) && Objects.isNull(otherIndex.getSequenceNumber())) {
+        return -1;
+      }
+      if (Objects.isNull(sequenceNumber) && !Objects.isNull(otherIndex.getSequenceNumber())) {
+        return 1;
+      }
+      return sequenceNumber.compareTo(otherIndex.getSequenceNumber());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o)
+        return true;
+      if (o == null || getClass() != o.getClass())
+        return false;
+      Index index = (Index) o;
+      return arrivalIndex == index.arrivalIndex && Objects.equals(sequenceNumber, index.sequenceNumber);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(sequenceNumber, arrivalIndex);
+    }
+  }
 }

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/content/SimpleAggregatedContent.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/content/SimpleAggregatedContent.java
@@ -10,6 +10,7 @@ import static java.util.stream.Collectors.toList;
 
 import org.mule.runtime.api.metadata.TypedValue;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,14 +27,14 @@ import java.util.Objects;
  */
 public class SimpleAggregatedContent extends AbstractAggregatedContent {
 
-  private static final long serialVersionUID = 5683523938853643505L;
+  private static final long serialVersionUID = -229638907750317297L;
 
   @Deprecated
-  /** TODO: fix this AMOD-5. This should be removed in the next major release. */
+  // TODO: fix this AMOD-5. This should be removed in the next major release.
   private Map<Integer, TypedValue> sequencedElements;
 
   @Deprecated
-  /** TODO: fix this AMOD-5. This should be removed in the next major release. */
+  // TODO: fix this AMOD-5. This should be removed in the next major release.
   private List<TypedValue> unsequencedElements;
 
   private Map<Index, TypedValue> indexedElements;
@@ -83,6 +84,18 @@ public class SimpleAggregatedContent extends AbstractAggregatedContent {
   }
 
   /**
+   * This method does a custom deserialization after the default deserialization to initialise the indexed elements
+   * because if a previous version was recovered this will not be initialized.
+   * TODO: fix this AMOD-5. This should be removed in the next major release.
+   */
+  private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    if (Objects.isNull(indexedElements)) {
+      indexedElements = new HashMap<>();
+    }
+  }
+
+  /**
    * This method upgrades the sequenced elements to the new data structure for backward compatibility.
    * TODO: fix this AMOD-5. This should be removed in the next major release.
    */
@@ -91,8 +104,8 @@ public class SimpleAggregatedContent extends AbstractAggregatedContent {
     if (!Objects.isNull(sequencedElements) && !sequencedElements.isEmpty()) {
       for (Integer key : sequencedElements.keySet()) {
         indexedElements.put(lastArrivalIndex(key), sequencedElements.get(key));
-        sequencedElements.remove(key);
       }
+      sequencedElements.clear();
     }
 
     if (!Objects.isNull(unsequencedElements) && !unsequencedElements.isEmpty()) {
@@ -113,7 +126,7 @@ public class SimpleAggregatedContent extends AbstractAggregatedContent {
 
   private static class Index implements Serializable, Comparable {
 
-    private static final long serialVersionUID = 7902763275773976860L;
+    private static final long serialVersionUID = -8286760373914606346L;
     private Integer sequenceNumber = null;
     private int arrivalIndex = 0;
 

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/info/AggregatorSharedInformation.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/info/AggregatorSharedInformation.java
@@ -10,4 +10,10 @@ import java.io.Serializable;
 
 public interface AggregatorSharedInformation extends Serializable {
 
+  /**
+   * This method upgrades the sequenced elements to the new data structure for backward compatibility.
+   * TODO: fix this AMOD-5. This should be removed in the next major release.
+   */
+  @Deprecated
+  void upgradeIfNeeded();
 }

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/info/AggregatorSharedInformation.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/info/AggregatorSharedInformation.java
@@ -10,9 +10,9 @@ import java.io.Serializable;
 
 public interface AggregatorSharedInformation extends Serializable {
 
+  // TODO: fix this AMOD-5. This should be removed in the next major release.
   /**
    * This method upgrades the sequenced elements to the new data structure for backward compatibility.
-   * TODO: fix this AMOD-5. This should be removed in the next major release.
    */
   @Deprecated
   void upgradeIfNeeded();

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/info/GroupAggregatorSharedInformation.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/info/GroupAggregatorSharedInformation.java
@@ -64,10 +64,10 @@ public class GroupAggregatorSharedInformation implements AggregatorSharedInforma
     return registeredTimeouts;
   }
 
+  // TODO: fix this AMOD-5. This should be removed in the next major release.
   /**
    * This method upgrades the sequenced elements to the new data structure for backward compatibility.
    * It is not necessary to do an upgrade for this class.
-   * TODO: fix this AMOD-5. This should be removed in the next major release.
    */
   @Override
   public void upgradeIfNeeded() {}

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/info/GroupAggregatorSharedInformation.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/info/GroupAggregatorSharedInformation.java
@@ -63,4 +63,12 @@ public class GroupAggregatorSharedInformation implements AggregatorSharedInforma
   public Map<String, AsyncTask> getRegisteredTimeoutAsyncAggregations() {
     return registeredTimeouts;
   }
+
+  /**
+   * This method upgrades the sequenced elements to the new data structure for backward compatibility.
+   * It is not necessary to do an upgrade for this class.
+   * TODO: fix this AMOD-5. This should be removed in the next major release.
+   */
+  @Override
+  public void upgradeIfNeeded() {}
 }

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/info/SimpleAggregatorSharedInformation.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/info/SimpleAggregatorSharedInformation.java
@@ -10,10 +10,12 @@ package org.mule.extension.aggregator.internal.storage.info;
 import org.mule.extension.aggregator.internal.storage.content.AggregatedContent;
 import org.mule.extension.aggregator.internal.task.AsyncTask;
 
+import java.util.Objects;
+
 
 public class SimpleAggregatorSharedInformation implements AggregatorSharedInformation {
 
-  private static final long serialVersionUID = 2720335740399722498L;
+  private static final long serialVersionUID = -6875380625504335868L;
   private AggregatedContent content;
   private String AggregationId;
   private AsyncTask asyncAggregationTask;
@@ -48,5 +50,17 @@ public class SimpleAggregatorSharedInformation implements AggregatorSharedInform
 
   public void setAggregationId(String aggregationId) {
     AggregationId = aggregationId;
+  }
+
+  /**
+   * This method upgrades the sequenced elements to the new data structure for backward compatibility.
+   * TODO: fix this AMOD-5. This should be removed in the next major release.
+   */
+  @Deprecated
+  @Override
+  public void upgradeIfNeeded() {
+    if (!Objects.isNull(this.content)) {
+      content.upgradeIfNeeded();
+    }
   }
 }

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/info/SimpleAggregatorSharedInformation.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/info/SimpleAggregatorSharedInformation.java
@@ -52,9 +52,9 @@ public class SimpleAggregatorSharedInformation implements AggregatorSharedInform
     AggregationId = aggregationId;
   }
 
+  // TODO: fix this AMOD-5. This should be removed in the next major release.
   /**
    * This method upgrades the sequenced elements to the new data structure for backward compatibility.
-   * TODO: fix this AMOD-5. This should be removed in the next major release.
    */
   @Deprecated
   @Override

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/info/SimpleAggregatorSharedInformation.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/info/SimpleAggregatorSharedInformation.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 
 public class SimpleAggregatorSharedInformation implements AggregatorSharedInformation {
 
-  private static final long serialVersionUID = -6875380625504335868L;
+  private static final long serialVersionUID = 2720335740399722498L;
   private AggregatedContent content;
   private String AggregationId;
   private AsyncTask asyncAggregationTask;

--- a/src/test/munit/aggregators-scenarios-test-case.xml
+++ b/src/test/munit/aggregators-scenarios-test-case.xml
@@ -181,6 +181,63 @@
         <munit-tools:queue/>
     </flow>
 
+    <munit:test name="testTimeBasedAggregationInsideScatterGather"
+                tags="Aggregators Extension,Integration Tests"
+                description="Verify the time based aggregator inside scatther-gather flow">
+        <munit:enable-flow-sources>
+            <munit:enable-flow-source value="flightOrdersAggregatorScatterListenerFlow"/>
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <file:read config-ref="fileConfig" path="#['input' ++ p('file.separator') ++ 'flight-orders.json']"/>
+
+            <foreach>
+                <scatter-gather>
+                    <route>
+                        <aggregators:time-based-aggregator period="${timeBasedAggregatorTimeout}" name="flightOrdersAggregatorScatter">
+                            <aggregators:content><![CDATA[#[%dw 2.0 output application/json --- payload]]]></aggregators:content>
+                            <aggregators:incremental-aggregation>
+                                <logger level="INFO" message="Flight order aggregated."/>
+                            </aggregators:incremental-aggregation>
+                        </aggregators:time-based-aggregator>
+                    </route>
+                    <route>
+                        <logger level="INFO" message="Flight order aggregated."/>
+                    </route>
+                </scatter-gather>
+                <choice>
+                    <when expression="#[(vars.counter mod 2) == 0]">
+                        <munit-tools:sleep time="${timeBasedAggregatorTimeoutSleep}" timeUnit="SECONDS"/>
+                    </when>
+                </choice>
+            </foreach>
+        </munit:execution>
+        <munit:validation>
+            <!-- Build the list of the expected flight aggregations to be performed by the app -->
+            <file:read config-ref="fileConfig" path="input/flight-orders.json"
+                       target="expectedAggregations"
+                       targetValue="#[%dw 2.0 import * from dw::core::Arrays --- payload divideBy ${aggregatorsSize}]"/>
+
+            <!-- Consume message of processed flight orders -->
+            <munit-tools:dequeue target="actualAggregations"
+                                 targetValue="#[%dw 2.0 output application/json --- payload orderBy($.date)]"/>
+
+            <munit-tools:assert-that expression="#[vars.actualAggregations]" is="#[MunitTools::equalTo(vars.expectedAggregations[0] orderBy($.date))]"/>
+
+            <!-- Consume message of processed flight orders -->
+            <munit-tools:dequeue target="actualAggregations"
+                                 targetValue="#[%dw 2.0 output application/json --- payload orderBy($.date)]"/>
+
+            <munit-tools:assert-that expression="#[vars.actualAggregations]" is="#[MunitTools::equalTo(vars.expectedAggregations[1] orderBy($.date))]"/>
+        </munit:validation>
+    </munit:test>
+
+    <flow name="flightOrdersAggregatorScatterListenerFlow">
+        <aggregators:aggregator-listener aggregatorName="flightOrdersAggregatorScatter"/>
+
+        <!-- Send flight orders to message queue -->
+        <munit-tools:queue/>
+    </flow>
+
     <!--  -->
     <!-- Migrated from mule-ee-distributions -->
     <!-- https://github.com/mulesoft/mule-ee-distributions/blob/eebf8f83189a0666bc5e36da849aa4c0c0e41fa1/tests/src/test/java/com/mulesoft/mule/distributions/server/integration/scenarios/AggregatorsScenariosTestCase.java#L267 -->

--- a/src/test/munit/aggregators-scenarios-test-case.xml
+++ b/src/test/munit/aggregators-scenarios-test-case.xml
@@ -183,7 +183,7 @@
 
     <munit:test name="testTimeBasedAggregationInsideScatterGather"
                 tags="Aggregators Extension,Integration Tests"
-                description="Verify the time based aggregator inside scatther-gather flow">
+                description="Verify the time based aggregator inside scatter-gather flow">
         <munit:enable-flow-sources>
             <munit:enable-flow-source value="flightOrdersAggregatorScatterListenerFlow"/>
         </munit:enable-flow-sources>
@@ -215,7 +215,7 @@
             <!-- Build the list of the expected flight aggregations to be performed by the app -->
             <file:read config-ref="fileConfig" path="input/flight-orders.json"
                        target="expectedAggregations"
-                       targetValue="#[%dw 2.0 import * from dw::core::Arrays --- payload divideBy ${aggregatorsSize}]"/>
+                       targetValue="#[%dw 2.0 import * from dw::core::Arrays --- ((1 to 2) flatMap payload) divideBy ${aggregatorsSize}]"/>
 
             <!-- Consume message of processed flight orders -->
             <munit-tools:dequeue target="actualAggregations"
@@ -233,6 +233,59 @@
 
     <flow name="flightOrdersAggregatorScatterListenerFlow">
         <aggregators:aggregator-listener aggregatorName="flightOrdersAggregatorScatter"/>
+
+        <!-- Send flight orders to message queue -->
+        <munit-tools:queue/>
+    </flow>
+
+    <munit:test name="testGroupBasedAggregationInsideForeach"
+                tags="Aggregators Extension,Integration Tests"
+                description="Verify the group based aggregator inside foreach flow">
+        <munit:enable-flow-sources>
+            <munit:enable-flow-source value="flightOrdersAggregatorForeachGroupFlow"/>
+            <munit:enable-flow-source value="flightOrdersAggregatorGroupListenerFlow"/>
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <file:read config-ref="fileConfig" path="#['input' ++ p('file.separator') ++ 'flight-orders.json']"/>
+            <flow-ref name="flightOrdersAggregatorForeachGroupFlow" />
+            <munit-tools:sleep time="${groupBasedAggregatorWaitSleep}" timeUnit="SECONDS"/>
+            <flow-ref name="flightOrdersAggregatorForeachGroupFlow" />
+        </munit:execution>
+        <munit:validation>
+            <!-- Build the list of the expected flight aggregations to be performed by the app -->
+            <file:read config-ref="fileConfig" path="input/flight-orders.json"
+                       target="expectedAggregations"
+                       targetValue="#[%dw 2.0 import * from dw::core::Arrays --- ((1 to 2) flatMap payload) divideBy ${groupBasedAggregatorSize}]"/>
+
+
+
+            <!-- Consume message of processed flight orders -->
+            <munit-tools:dequeue target="actualAggregations"
+                                 targetValue="#[%dw 2.0 output application/json --- payload orderBy($.date)]"/>
+
+            <munit-tools:assert-that expression="#[vars.actualAggregations]" is="#[MunitTools::equalTo(vars.expectedAggregations[0] orderBy($.date))]"/>
+
+        </munit:validation>
+    </munit:test>
+
+    <flow name="flightOrdersAggregatorForeachGroupFlow">
+
+        <foreach>
+            <set-variable variableName="groupId" value="1"/>
+            <aggregators:group-based-aggregator name="flightOrdersAggregatorForeach" groupId="#[vars.groupId]" groupSize="${groupBasedAggregatorSize}" evictionTime="-1">
+                <aggregators:content><![CDATA[#[%dw 2.0 output application/json --- payload]]]></aggregators:content>
+                <aggregators:incremental-aggregation>
+                    <logger level="INFO" message="Flight order aggregated."/>
+                </aggregators:incremental-aggregation>
+                <aggregators:aggregation-complete>
+                    <logger level="INFO" message="Max size reached. Aggregate complete." />
+                </aggregators:aggregation-complete>
+            </aggregators:group-based-aggregator>
+        </foreach>
+    </flow>
+
+    <flow name="flightOrdersAggregatorGroupListenerFlow">
+        <aggregators:aggregator-listener aggregatorName="flightOrdersAggregatorForeach"/>
 
         <!-- Send flight orders to message queue -->
         <munit-tools:queue/>

--- a/src/test/munit/aggregators-scenarios-test-case.xml
+++ b/src/test/munit/aggregators-scenarios-test-case.xml
@@ -21,7 +21,7 @@
 
     <os:object-store name="objectStore" persistent="false" />
 
-    <munit:config name="aggregators-scenarios"/>
+    <munit:config name="aggregators-scenarios" minMuleVersion="4.2.2"/>
 
     <!--  -->
     <!-- Migrated from mule-ee-distributions -->

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -3,6 +3,9 @@ sizeBasedAggregatorTimeout=3
 sizeBasedAggregatorTimeoutSleep=4
 timeBasedAggregatorTimeout=2
 timeBasedAggregatorTimeoutSleep=4
+groupBasedAggregatorWaitSleep=1
+groupBasedAggregatorSize=8
+
 
 aggregatorsSchedulingPeriod=100
 configuredAggregatorTimeout=60000


### PR DESCRIPTION
Problem Description:
Messages getting lost in Group-based Aggregator.
Messages are not coming to the Aggregator listener for some of the groups.
This contemplates the "AMOD-2: fix aggregator inside scatter-gather not working properly" case.

Cause:
The aggregator can receive sequences from different events so this results in some elements of different sequences to be replaced in case the items are aggregated from multiple events.

This PR replaces AMOD-2: https://github.com/mulesoft/mule-aggregators-module/pull/88
because it makes the implementation backward compatible

The solution will be that each value of sequencedElements is a list instead of a single element. In order to add elements for each sequence number and return the different lists as a single list grouped and sorted by their sequence number.