### PR TITLE
AMOD-8: Fix content push without changes to the object store.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
-        <muleObjectStoreConnectorTestVersion>1.2.0-SNAPSHOT</muleObjectStoreConnectorTestVersion>
+        <muleObjectStoreConnectorTestVersion>1.2.0</muleObjectStoreConnectorTestVersion>
         <muleFileConnectorTestVersion>1.3.4</muleFileConnectorTestVersion>
         <muleTestsComponentPlugin>4.1.5</muleTestsComponentPlugin>
         <muleVmConnectorTestVersion>2.0.0</muleVmConnectorTestVersion>

--- a/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/GroupBasedAggregatorOperationsExecutor.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/GroupBasedAggregatorOperationsExecutor.java
@@ -146,6 +146,7 @@ public class GroupBasedAggregatorOperationsExecutor extends AbstractAggregatorEx
       } else {
         future.complete(Result.builder().build());
       }
+      return true;
     });
 
     finishExecution(future, completionCallback);
@@ -279,15 +280,17 @@ public class GroupBasedAggregatorOperationsExecutor extends AbstractAggregatorEx
   }
 
   @Override
-  void doScheduleRegisteredAsyncAggregations() {
+  boolean doScheduleRegisteredAsyncAggregations() {
     getSharedInfoLocalCopy().getRegisteredGroupEvictionTasks().forEach(this::scheduleGroupEvictionIfNeeded);
     getSharedInfoLocalCopy().getRegisteredTimeoutAsyncAggregations().forEach(this::scheduleTimeoutIfNeeded);
+    return true;
   }
 
   @Override
-  void doSetRegisteredAsyncAggregationsAsNotScheduled() {
+  boolean doSetRegisteredAsyncAggregationsAsNotScheduled() {
     getSharedInfoLocalCopy().getRegisteredGroupEvictionTasks().forEach((key, value) -> value.setUnscheduled());
     getSharedInfoLocalCopy().getRegisteredTimeoutAsyncAggregations().forEach((key, value) -> value.setUnscheduled());
+    return true;
   }
 
   private void scheduleGroupEvictionIfNeeded(String groupId, AsyncTask task) {
@@ -295,6 +298,7 @@ public class GroupBasedAggregatorOperationsExecutor extends AbstractAggregatorEx
       scheduleTask(task, () -> executeSynchronized(() -> {
         onGroupEviction(groupId);
         getSharedInfoLocalCopy().unregisterGroupEvictionTask(groupId);
+        return true;
       }));
       task.setScheduled();
       if (LOGGER.isDebugEnabled()) {
@@ -319,6 +323,7 @@ public class GroupBasedAggregatorOperationsExecutor extends AbstractAggregatorEx
           onTimeout(groupId);
           getSharedInfoLocalCopy().unregisterTimeoutAsyncAggregation(groupId);
         }
+        return true;
       }));
       task.setScheduled();
       if (LOGGER.isDebugEnabled()) {

--- a/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/SingleGroupAggregatorExecutor.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/SingleGroupAggregatorExecutor.java
@@ -82,7 +82,7 @@ public abstract class SingleGroupAggregatorExecutor extends AbstractAggregatorEx
   }
 
   @Override
-  void doScheduleRegisteredAsyncAggregations() {
+  boolean doScheduleRegisteredAsyncAggregations() {
     final AsyncTask task = getSharedInfoLocalCopy().getRegisteredAsyncAggregationTask();
     if (task != null) {
       if (!task.isScheduled()) {
@@ -93,7 +93,9 @@ public abstract class SingleGroupAggregatorExecutor extends AbstractAggregatorEx
               && task.getId().equals(getSharedInfoLocalCopy().getRegisteredAsyncAggregationTask().getId())) {
             onAsyncAggregationExecution();
             getSharedInfoLocalCopy().unregisterAsyncAggregationTask();
+            return true;
           }
+          return false;
         }));
         task.setScheduled();
         if (LOGGER.isDebugEnabled()) {
@@ -104,15 +106,19 @@ public abstract class SingleGroupAggregatorExecutor extends AbstractAggregatorEx
           LOGGER.debug("Attempted to schedule task but it was already scheduled");
         }
       }
+      return true;
     }
+    return false;
   }
 
   @Override
-  void doSetRegisteredAsyncAggregationsAsNotScheduled() {
+  boolean doSetRegisteredAsyncAggregationsAsNotScheduled() {
     AsyncTask task = getSharedInfoLocalCopy().getRegisteredAsyncAggregationTask();
     if (task != null) {
       task.setUnscheduled();
+      return true;
     }
+    return false;
   }
 
   abstract void onAsyncAggregationExecution();

--- a/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/SizeBasedAggregatorOperationsExecutor.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/SizeBasedAggregatorOperationsExecutor.java
@@ -123,6 +123,7 @@ public class SizeBasedAggregatorOperationsExecutor extends SingleGroupAggregator
       } else {
         future.complete(Result.builder().build());
       }
+      return true;
     });
 
     finishExecution(future, completionCallback);

--- a/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/TimeBasedAggregatorOperationsExecutor.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/privileged/executor/TimeBasedAggregatorOperationsExecutor.java
@@ -116,6 +116,7 @@ public class TimeBasedAggregatorOperationsExecutor extends SingleGroupAggregator
       } else {
         future.complete(Result.builder().build());
       }
+      return true;
     });
 
     finishExecution(future, completionCallback);

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/content/AggregatedContent.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/content/AggregatedContent.java
@@ -62,8 +62,10 @@ public interface AggregatedContent extends Serializable {
   // TODO: fix this AMOD-5. This should be removed in the next major release.
   /**
    * This method upgrades the sequenced elements to the new data structure for backward compatibility.
+   *
+   * @return true if the upgrade was made, false otherwise.
    */
   @Deprecated
-  public void upgradeIfNeeded();
+  public boolean upgradeIfNeeded();
 
 }

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/content/SimpleAggregatedContent.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/content/SimpleAggregatedContent.java
@@ -96,9 +96,9 @@ public class SimpleAggregatedContent extends AbstractAggregatedContent {
    * This method upgrades the sequenced elements to the new data structure for backward compatibility.
    */
   @Deprecated
-  public void upgradeIfNeeded() {
+  public boolean upgradeIfNeeded() {
     if (sequencedElements.isEmpty()) {
-      return;
+      return false;
     }
 
     // TODO: fix this AMOD-5. For sequenced elements use the class Index instead of using the SequencedElement class to
@@ -113,7 +113,9 @@ public class SimpleAggregatedContent extends AbstractAggregatedContent {
       }
       sequencedElements.clear();
       sequencedElements = indexedElements;
+      return true;
     }
+    return false;
   }
 
   // TODO: fix this AMOD-5. This should be removed in the next major release.

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/info/AggregatorSharedInformation.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/info/AggregatorSharedInformation.java
@@ -13,7 +13,9 @@ public interface AggregatorSharedInformation extends Serializable {
   // TODO: fix this AMOD-5. This should be removed in the next major release.
   /**
    * This method upgrades the sequenced elements to the new data structure for backward compatibility.
+   *
+   * @return true if the upgrade was made, false otherwise.
    */
   @Deprecated
-  void upgradeIfNeeded();
+  boolean upgradeIfNeeded();
 }

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/info/GroupAggregatorSharedInformation.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/info/GroupAggregatorSharedInformation.java
@@ -70,5 +70,7 @@ public class GroupAggregatorSharedInformation implements AggregatorSharedInforma
    * It is not necessary to do an upgrade for this class.
    */
   @Override
-  public void upgradeIfNeeded() {}
+  public boolean upgradeIfNeeded() {
+    return false;
+  }
 }

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/info/SimpleAggregatorSharedInformation.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/info/SimpleAggregatorSharedInformation.java
@@ -58,9 +58,10 @@ public class SimpleAggregatorSharedInformation implements AggregatorSharedInform
    */
   @Deprecated
   @Override
-  public void upgradeIfNeeded() {
+  public boolean upgradeIfNeeded() {
     if (!Objects.isNull(this.content)) {
-      content.upgradeIfNeeded();
+      return content.upgradeIfNeeded();
     }
+    return false;
   }
 }

--- a/src/test/java/org/mule/extension/aggregator/AsyncTasksAfterRestartTestCase.java
+++ b/src/test/java/org/mule/extension/aggregator/AsyncTasksAfterRestartTestCase.java
@@ -11,6 +11,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.disposeIfNeeded;
@@ -177,6 +179,87 @@ public class AsyncTasksAfterRestartTestCase extends AbstractMuleContextTestCase 
 
     // ...then check that the pending aggregation timeout event is triggered after restarting on its due time
     aggregatorExecutorRedeploy = new SizeBasedAggregatorOperationsExecutor(params);
+    startUp(aggregatorListener);
+
+    assertAsyncAggregation(sourceCallback, sourceCallbackCtx);
+  }
+
+  @Test
+  @Description("Avoid race condition in object store after redeploy in sizeBasedAggregator")
+  public void sizeBasedAggregatorDoesNotPushToObjectStoreWhenNoChanges() throws Exception {
+    final Map<String, Object> params = new HashMap<>();
+    SimpleMemoryObjectStore mockedObjectStore = spy(SimpleMemoryObjectStore.class);
+    params.put("objectStore", mockedObjectStore);
+    params.put("name", "aggregator");
+    params.put("maxSize", 2);
+
+    final SizeBasedAggregatorOperationsExecutor aggregatorExecutor = new SizeBasedAggregatorOperationsExecutor(params);
+
+    initialiseIfNeeded(aggregatorExecutor, muleContext);
+    startIfNeeded(aggregatorExecutor);
+
+    final AggregatorListener aggregatorListener = mock(AggregatorListener.class);
+    when(aggregatorListener.getCallback()).thenReturn(sourceCallback);
+    when(aggregatorListener.shouldIncludeTimedOutGroups()).thenReturn(true);
+    aggregatorManager.registerListener("aggregator", aggregatorListener);
+
+    verify(mockedObjectStore, never()).store(any(), any());
+
+    final Map<String, Object> operationParams = new HashMap<>();
+    operationParams.put("content", new TypedValue<>("testPayload", DataType.STRING));
+    operationParams.put("timeout", RECEIVE_TIMEOUT);
+    operationParams.put("timeoutUnit", MILLISECONDS);
+    addItemToAggregation(aggregatorExecutor, operationParams);
+
+    // Wait until just before the aggregation times out to do a restart...
+    Thread.sleep(3000);
+
+    verify(mockedObjectStore).store(any(), any());
+
+    shutdown(aggregatorExecutor);
+
+    // ...then check that the pending aggregation timeout event is triggered after restarting on its due time
+    aggregatorExecutorRedeploy = new SizeBasedAggregatorOperationsExecutor(params);
+    startUp(aggregatorListener);
+
+    assertAsyncAggregation(sourceCallback, sourceCallbackCtx);
+  }
+
+  @Test
+  @Description("Avoid race condition in object store after redeploy in timeBasedAggregator")
+  public void timeBasedAggregatorDoesNotPushToObjectStoreWhenNoChanges() throws Exception {
+    final Map<String, Object> params = new HashMap<>();
+    SimpleMemoryObjectStore mockedObjectStore = spy(SimpleMemoryObjectStore.class);
+    params.put("objectStore", mockedObjectStore);
+    params.put("name", "aggregator");
+    params.put("maxSize", -1);
+
+    final TimeBasedAggregatorOperationsExecutor aggregatorExecutor = new TimeBasedAggregatorOperationsExecutor(params);
+
+    initialiseIfNeeded(aggregatorExecutor, muleContext);
+    startIfNeeded(aggregatorExecutor);
+
+    final AggregatorListener aggregatorListener = mock(AggregatorListener.class);
+    when(aggregatorListener.getCallback()).thenReturn(sourceCallback);
+    aggregatorManager.registerListener("aggregator", aggregatorListener);
+
+    verify(mockedObjectStore, never()).store(any(), any());
+
+    final Map<String, Object> operationParams = new HashMap<>();
+    operationParams.put("content", new TypedValue<>("testPayload", DataType.STRING));
+    operationParams.put("period", RECEIVE_TIMEOUT);
+    operationParams.put("periodUnit", MILLISECONDS);
+    addItemToAggregation(aggregatorExecutor, operationParams);
+
+    // Wait until just before the aggregation times out to do a restart...
+    Thread.sleep(3000);
+
+    verify(mockedObjectStore).store(any(), any());
+
+    shutdown(aggregatorExecutor);
+
+    // ...then check that the pending aggregation timeout event is triggered after restarting on its due time
+    aggregatorExecutorRedeploy = new TimeBasedAggregatorOperationsExecutor(params);
     startUp(aggregatorListener);
 
     assertAsyncAggregation(sourceCallback, sourceCallbackCtx);

--- a/src/test/java/org/mule/extension/aggregator/AsyncTasksAfterRestartTestCase.java
+++ b/src/test/java/org/mule/extension/aggregator/AsyncTasksAfterRestartTestCase.java
@@ -211,9 +211,6 @@ public class AsyncTasksAfterRestartTestCase extends AbstractMuleContextTestCase 
     operationParams.put("timeoutUnit", MILLISECONDS);
     addItemToAggregation(aggregatorExecutor, operationParams);
 
-    // Wait until just before the aggregation times out to do a restart...
-    Thread.sleep(3000);
-
     verify(mockedObjectStore).store(any(), any());
 
     shutdown(aggregatorExecutor);
@@ -250,9 +247,6 @@ public class AsyncTasksAfterRestartTestCase extends AbstractMuleContextTestCase 
     operationParams.put("period", RECEIVE_TIMEOUT);
     operationParams.put("periodUnit", MILLISECONDS);
     addItemToAggregation(aggregatorExecutor, operationParams);
-
-    // Wait until just before the aggregation times out to do a restart...
-    Thread.sleep(3000);
 
     verify(mockedObjectStore).store(any(), any());
 


### PR DESCRIPTION
According to AMOD-7, a correction should be made to avoid pushing the shared information from the aggregator to the object store when there are no changes.

To address this, the executeSynchronized() method parameter was changed to receive a Supplier<Boolean> instead of a Runnable task, so that a return value can be computed and used to push into the object store only if changes were made.
