### PR TITLE
AMOD-9: Update messages pending aggregation in ObjectStore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
-        <muleObjectStoreConnectorTestVersion>1.2.0-SNAPSHOT</muleObjectStoreConnectorTestVersion>
+        <muleObjectStoreConnectorTestVersion>1.2.0</muleObjectStoreConnectorTestVersion>
         <muleFileConnectorTestVersion>1.3.4</muleFileConnectorTestVersion>
         <muleTestsComponentPlugin>4.1.5</muleTestsComponentPlugin>
         <muleVmConnectorTestVersion>2.0.0</muleVmConnectorTestVersion>
@@ -152,7 +152,20 @@
             <version>4.2.0</version>
             <scope>test</scope>
         </dependency>
-        
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>5.3.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>5.3.6</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <distributionManagement>

--- a/src/main/java/org/mule/extension/aggregator/internal/storage/info/GroupAggregatorSharedInformation.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/storage/info/GroupAggregatorSharedInformation.java
@@ -12,6 +12,7 @@ import org.mule.extension.aggregator.internal.task.AsyncTask;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class GroupAggregatorSharedInformation implements AggregatorSharedInformation {
 
@@ -69,6 +70,13 @@ public class GroupAggregatorSharedInformation implements AggregatorSharedInforma
    * This method upgrades the sequenced elements to the new data structure for backward compatibility.
    * It is not necessary to do an upgrade for this class.
    */
+  @Deprecated
   @Override
-  public void upgradeIfNeeded() {}
+  public void upgradeIfNeeded() {
+    for (AggregatedContent aggregatedContent : contentMap.values()) {
+      if ((!Objects.isNull(aggregatedContent))) {
+        aggregatedContent.upgradeIfNeeded();
+      }
+    }
+  }
 }

--- a/src/test/java/org/mule/extension/aggregator/AsyncTasksAfterRestartTestCase.java
+++ b/src/test/java/org/mule/extension/aggregator/AsyncTasksAfterRestartTestCase.java
@@ -10,6 +10,7 @@ import static java.util.Optional.empty;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -22,16 +23,22 @@ import static org.mule.tck.probe.PollingProber.probe;
 import static org.mule.test.allure.AllureConstants.AggregatorsFeature.AGGREGATORS_EXTENSION;
 
 import org.mule.extension.aggregator.internal.config.AggregatorManager;
-import org.mule.extension.aggregator.internal.privileged.executor.SingleGroupAggregatorExecutor;
+import org.mule.extension.aggregator.internal.privileged.executor.AbstractAggregatorExecutor;
+import org.mule.extension.aggregator.internal.privileged.executor.GroupBasedAggregatorOperationsExecutor;
 import org.mule.extension.aggregator.internal.privileged.executor.SizeBasedAggregatorOperationsExecutor;
 import org.mule.extension.aggregator.internal.privileged.executor.TimeBasedAggregatorOperationsExecutor;
+import org.mule.extension.aggregator.internal.routes.AggregationCompleteRoute;
 import org.mule.extension.aggregator.internal.source.AggregatorListener;
+import org.mule.extension.aggregator.internal.storage.content.SimpleAggregatedContent;
+import org.mule.extension.aggregator.internal.storage.info.GroupAggregatorSharedInformation;
 import org.mule.runtime.api.component.ConfigurationProperties;
 import org.mule.runtime.api.exception.MuleException;
 import org.mule.runtime.api.lifecycle.InitialisationException;
+import org.mule.runtime.api.message.ItemSequenceInfo;
 import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.store.SimpleMemoryObjectStore;
+import org.mule.runtime.core.api.event.CoreEvent;
 import org.mule.runtime.core.internal.cluster.DefaultClusterService;
 import org.mule.runtime.core.internal.context.MuleContextWithRegistries;
 import org.mule.runtime.core.privileged.registry.RegistrationException;
@@ -40,11 +47,13 @@ import org.mule.runtime.extension.api.runtime.process.CompletionCallback;
 import org.mule.runtime.extension.api.runtime.source.SourceCallback;
 import org.mule.runtime.extension.api.runtime.source.SourceCallbackContext;
 import org.mule.runtime.module.extension.api.runtime.privileged.ExecutionContextAdapter;
+import org.mule.runtime.module.extension.internal.runtime.operation.ImmutableProcessorChainExecutor;
 import org.mule.tck.junit4.AbstractMuleContextTestCase;
 
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.junit.After;
 import org.junit.Before;
@@ -56,11 +65,15 @@ import org.slf4j.LoggerFactory;
 import io.qameta.allure.Description;
 import io.qameta.allure.Feature;
 import io.qameta.allure.Step;
+import org.springframework.test.util.ReflectionTestUtils;
+
 
 @Feature(AGGREGATORS_EXTENSION)
 public class AsyncTasksAfterRestartTestCase extends AbstractMuleContextTestCase {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AsyncTasksAfterRestartTestCase.class);
+
+  private static final String AGGREGATOR_COMPLETE_CALLBACK_CONTEXT_PARAM = "aggregationComplete";
 
   private SimpleMemoryObjectStore<Serializable> objectStore;
 
@@ -70,7 +83,7 @@ public class AsyncTasksAfterRestartTestCase extends AbstractMuleContextTestCase 
 
   private SourceCallbackContext sourceCallbackCtx;
 
-  private SingleGroupAggregatorExecutor aggregatorExecutorRedeploy;
+  private AbstractAggregatorExecutor aggregatorExecutorRedeploy;
 
   @Override
   protected Map<String, Object> getStartUpRegistryObjects() {
@@ -129,6 +142,7 @@ public class AsyncTasksAfterRestartTestCase extends AbstractMuleContextTestCase 
     operationParams.put("content", new TypedValue<>("testPayload", DataType.STRING));
     operationParams.put("period", RECEIVE_TIMEOUT);
     operationParams.put("periodUnit", MILLISECONDS);
+    operationParams.put("sequenceNumber", 1);
     addItemToAggregation(aggregatorExecutor, operationParams);
 
     // Wait until just before the aggregation times out to do a restart...
@@ -182,8 +196,63 @@ public class AsyncTasksAfterRestartTestCase extends AbstractMuleContextTestCase 
     assertAsyncAggregation(sourceCallback, sourceCallbackCtx);
   }
 
-  private void addItemToAggregation(final SingleGroupAggregatorExecutor aggregatorExecutor,
+  @Test
+  @Description("Update messages pending aggregation in ObjectStore when upgrading to 1.0.3")
+  public void groupBasedAggregatorCompatibilityWithPreviousVersion() throws Exception {
+    final Map<String, Object> params = new HashMap<>();
+    SimpleMemoryObjectStore mockedObjectStore = new SimpleMemoryObjectStore();
+    GroupAggregatorSharedInformation sharedInformation = new GroupAggregatorSharedInformation();
+    SimpleAggregatedContent simpleAggregatedContent = new SimpleAggregatedContent(3);
+    Map<Integer, TypedValue> oldSequencedElements = new HashMap<>();
+    oldSequencedElements.put(1, TypedValue.of("value1"));
+    oldSequencedElements.put(2, TypedValue.of("value2"));
+
+    ReflectionTestUtils.setField(simpleAggregatedContent, "sequencedElements", oldSequencedElements, Map.class);
+    sharedInformation.setAggregatedContent("1", simpleAggregatedContent);
+    String aggregatorKey = "AGGREGATORS:GroupBasedAggregator:aggregator";
+    mockedObjectStore.store(aggregatorKey, sharedInformation);
+
+    params.put("objectStore", mockedObjectStore);
+    params.put("name", "aggregator");
+    params.put("maxSize", 3);
+
+    final GroupBasedAggregatorOperationsExecutor aggregatorExecutor = new GroupBasedAggregatorOperationsExecutor(params);
+
+
+    initialiseIfNeeded(aggregatorExecutor, muleContext);
+    startIfNeeded(aggregatorExecutor);
+
+    final AggregatorListener aggregatorListener = mock(AggregatorListener.class);
+    when(aggregatorListener.getCallback()).thenReturn(sourceCallback);
+    when(aggregatorListener.shouldIncludeTimedOutGroups()).thenReturn(true);
+    aggregatorManager.registerListener("aggregator", aggregatorListener);
+
+    final Map<String, Object> operationParams = new HashMap<>();
+    operationParams.put("content", new TypedValue<>("testPayload", DataType.STRING));
+    operationParams.put("timeout", RECEIVE_TIMEOUT);
+    operationParams.put("timeoutUnit", MILLISECONDS);
+    operationParams.put("evictionTime", RECEIVE_TIMEOUT);
+    operationParams.put("evictionTimeUnit", MILLISECONDS);
+    operationParams.put("groupId", "1");
+    operationParams.put("groupSize", 1);
+    operationParams.put("aggregationComplete", mock(CompletionCallback.class));
+    addItemToAggregation(aggregatorExecutor, operationParams);
+
+    shutdown(aggregatorExecutor);
+
+    // ...then check that the pending aggregation timeout event is triggered after restarting on its due time
+    aggregatorExecutorRedeploy = new GroupBasedAggregatorOperationsExecutor(params);
+    startUp(aggregatorListener);
+  }
+
+  private void addItemToAggregation(final AbstractAggregatorExecutor aggregatorExecutor,
                                     final Map<String, Object> operationParams)
+      throws MuleException {
+    addItemToAggregation(aggregatorExecutor, operationParams, null);
+  }
+
+  private void addItemToAggregation(final AbstractAggregatorExecutor aggregatorExecutor,
+                                    final Map<String, Object> operationParams, Integer sequenceNumber)
       throws MuleException {
     final ExecutionContextAdapter executionCtx = mock(ExecutionContextAdapter.class);
 
@@ -191,11 +260,30 @@ public class AsyncTasksAfterRestartTestCase extends AbstractMuleContextTestCase 
     when(executionCtx.getEvent()).thenReturn(testEvent());
     when(executionCtx.getVariable(COMPLETION_CALLBACK_CONTEXT_PARAM)).thenReturn(mock(CompletionCallback.class));
 
+    AggregationCompleteRoute aggregationCompleteRoute = mock(AggregationCompleteRoute.class);
+    ImmutableProcessorChainExecutor chain = mock(ImmutableProcessorChainExecutor.class);
+
+    doAnswer(invocation -> {
+      Consumer<Result> futureComplete = invocation.getArgumentAt(2, Consumer.class);
+      futureComplete.accept(Result.builder().build());
+      return null;
+    }).when(chain).process(any(), any(), any(), any());
+
+    when(aggregationCompleteRoute.getChain()).thenReturn(chain);
+    when(executionCtx.getParameter(AGGREGATOR_COMPLETE_CALLBACK_CONTEXT_PARAM)).thenReturn(aggregationCompleteRoute);
+
+    if (sequenceNumber != null) {
+      ItemSequenceInfo mockItemSequenceInfo = ItemSequenceInfo.of(sequenceNumber);
+      CoreEvent mockCoreEvent = mock(CoreEvent.class);
+      when(mockCoreEvent.getItemSequenceInfo()).thenReturn(java.util.Optional.of(mockItemSequenceInfo));
+      when(executionCtx.getEvent()).thenReturn(mockCoreEvent);
+    }
+
     aggregatorExecutor.execute(executionCtx);
   }
 
   @Step("Simulate a shutdown of the runtime only affecting the relevant components")
-  private void shutdown(final SingleGroupAggregatorExecutor aggregatorExecutor) throws MuleException {
+  private void shutdown(final AbstractAggregatorExecutor aggregatorExecutor) throws MuleException {
     stopIfNeeded(aggregatorExecutor);
     stopIfNeeded(aggregatorManager);
     disposeIfNeeded(aggregatorExecutor, LOGGER);


### PR DESCRIPTION
Update messages pending aggregation in ObjectStore when upgrading to 1.0.3 in group-based aggregators.

Added the missing upgradeIfNeeded() call for the GroupAggregatorSharedInformation aggregated contents.