### PR TITLE
AMOD-11: Unregister aggregator listeners on stop

### DIFF
--- a/src/main/java/org/mule/extension/aggregator/internal/config/AggregatorManager.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/config/AggregatorManager.java
@@ -189,6 +189,23 @@ public class AggregatorManager implements Lifecycle {
   }
 
   /**
+   * Unregisters a listener from an already registered aggregator
+   *
+   * @param aggregatorName the name of the aggregator to unregister from
+   * @param listener the listener to be called when needed
+   * @throws MuleRuntimeException
+   */
+  public void unregisterListener(String aggregatorName, AggregatorListener listener) throws MuleRuntimeException {
+    if (!availableAggregators.containsKey(aggregatorName)) {
+      throw new MuleRuntimeException(createStaticMessage("Listener is attempting to unregister from aggregator: '%s', but it does not exist",
+                                                         aggregatorName));
+    }
+    if (registeredListeners.containsKey(aggregatorName)) {
+      registeredListeners.remove(aggregatorName, listener);
+    }
+  }
+
+  /**
    * Get the listener registered to the aggregator with {@param aggregatorName}
    * <p/>
    * If the aggregator does not have any listener registered to it an {@link Optional#empty()} will be returned

--- a/src/main/java/org/mule/extension/aggregator/internal/config/AggregatorManager.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/config/AggregatorManager.java
@@ -200,8 +200,7 @@ public class AggregatorManager implements Lifecycle {
       throw new MuleRuntimeException(createStaticMessage("Listener is attempting to unregister from aggregator: '%s', but it does not exist",
                                                          aggregatorName));
     }
-    boolean unregisterSuccessful = registeredListeners.remove(aggregatorName, listener);
-    if (!unregisterSuccessful) {
+    if (!registeredListeners.remove(aggregatorName, listener)) {
       LOGGER.error(format("Listener is attempting to unregister from aggregator: '%s', but it does not exist", aggregatorName));
     }
   }

--- a/src/main/java/org/mule/extension/aggregator/internal/config/AggregatorManager.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/config/AggregatorManager.java
@@ -200,8 +200,9 @@ public class AggregatorManager implements Lifecycle {
       throw new MuleRuntimeException(createStaticMessage("Listener is attempting to unregister from aggregator: '%s', but it does not exist",
                                                          aggregatorName));
     }
-    if (registeredListeners.containsKey(aggregatorName)) {
-      registeredListeners.remove(aggregatorName, listener);
+    boolean unregisterSuccessful = registeredListeners.remove(aggregatorName, listener);
+    if (!unregisterSuccessful) {
+      LOGGER.error(format("Listener is attempting to unregister from aggregator: '%s', but it does not exist", aggregatorName));
     }
   }
 

--- a/src/main/java/org/mule/extension/aggregator/internal/source/AggregatorListener.java
+++ b/src/main/java/org/mule/extension/aggregator/internal/source/AggregatorListener.java
@@ -60,6 +60,7 @@ public class AggregatorListener extends Source<Message, AggregationAttributes> {
   public void onStop() {
     synchronized (startLock) {
       started = false;
+      manager.unregisterListener(aggregatorName, this);
     }
   }
 

--- a/src/test/java/org/mule/extension/aggregator/munit/AggregatorTestUtils.java
+++ b/src/test/java/org/mule/extension/aggregator/munit/AggregatorTestUtils.java
@@ -51,4 +51,26 @@ public final class AggregatorTestUtils {
     return payload;
   }
 
+  public static Object restartAggregatorWithoutDispose(Object payload, Object aggregatorManager,
+                                                       ConfigurationComponentLocator locator,
+                                                       String aggregatorRoute) {
+    LOGGER.debug(" >> registry: " + aggregatorManager.toString());
+    final Component aggregator = locator.find(Location.builderFromStringRepresentation(aggregatorRoute).build()).get();
+    LOGGER.debug(" >> registry: " + aggregator.toString());
+
+    try {
+      ((Stoppable) aggregator).stop();
+      ((Stoppable) aggregatorManager).stop();
+
+      ((Initialisable) aggregatorManager).initialise();
+      ((Initialisable) aggregator).initialise();
+      ((Startable) aggregatorManager).start();
+      ((Startable) aggregator).start();
+    } catch (MuleException e) {
+      LOGGER.error("Error restarting aggregator " + aggregatorRoute, e);
+      throw new MuleRuntimeException(e);
+    }
+
+    return payload;
+  }
 }

--- a/src/test/java/org/mule/extension/aggregator/munit/AggregatorTestUtils.java
+++ b/src/test/java/org/mule/extension/aggregator/munit/AggregatorTestUtils.java
@@ -62,8 +62,6 @@ public final class AggregatorTestUtils {
       ((Stoppable) aggregator).stop();
       ((Stoppable) aggregatorManager).stop();
 
-      ((Initialisable) aggregatorManager).initialise();
-      ((Initialisable) aggregator).initialise();
       ((Startable) aggregatorManager).start();
       ((Startable) aggregator).start();
     } catch (MuleException e) {

--- a/src/test/munit/aggregators-restart-test-case.xml
+++ b/src/test/munit/aggregators-restart-test-case.xml
@@ -115,35 +115,6 @@
         </munit:execution>
     </munit:test>
 
-    <munit:test name="unregisterAggregatorListenerWhenRestarting"
-                tags="Aggregators Extension"
-                description="Unregister Aggregator Listener When Restarting">
-        <munit:enable-flow-sources>
-            <munit:enable-flow-source value="tbaAggregatorListenerFlow"/>
-        </munit:enable-flow-sources>
-        <munit:execution>
-            <set-variable variableName="result" value="NOT_COMPLETE"/>
-            <aggregators:size-based-aggregator name="sba"  maxSize="1">
-                <aggregators:content>#['testPayload']</aggregators:content>
-                <aggregators:aggregation-complete>
-                    <set-variable variableName="result" value="COMPLETE"/>
-                </aggregators:aggregation-complete>
-            </aggregators:size-based-aggregator>
-
-            <munit-tools:assert-that expression="#[vars.result]" is="#[MunitTools::equalTo('COMPLETE')]"/>
-            <!-- restart! -->
-            <set-payload value="#[java!org::mule::extension::aggregator::munit::AggregatorTestUtils::restartAggregatorWithoutDispose(payload, app.registry['aggregators.aggregatorManager'], app.registry['_muleConfigurationComponentLocator'], 'unregisterAggregatorListenerWhenRestarting/route/1/processors/1')]"/>
-            <set-payload value="#[java!org::mule::extension::aggregator::munit::AggregatorTestUtils::restartAggregatorWithoutDispose(payload, app.registry['aggregators.aggregatorManager'], app.registry['_muleConfigurationComponentLocator'], 'tbaAggregatorListenerFlow/source')]"/>
-
-        </munit:execution>
-    </munit:test>
-
-    <flow name="tbaAggregatorListenerFlow">
-        <aggregators:aggregator-listener aggregatorName="sba"/>
-
-        <logger level="WARN" message="tbaAggregatorListenerFlow"/>
-    </flow>
-
     <!--  -->
     <!-- Migrated from mule-ee-distributions -->
     <!-- https://github.com/mulesoft/mule-ee-distributions/blob/eebf8f83189a0666bc5e36da849aa4c0c0e41fa1/tests/src/test/java/com/mulesoft/mule/distributions/server/AggregatorsTestCase.java#L126 -->

--- a/src/test/munit/aggregators-restart-test-case.xml
+++ b/src/test/munit/aggregators-restart-test-case.xml
@@ -115,6 +115,35 @@
         </munit:execution>
     </munit:test>
 
+    <munit:test name="unregisterAggregatorListenerWhenRestarting"
+                tags="Aggregators Extension"
+                description="Unregister Aggregator Listener When Restarting">
+        <munit:enable-flow-sources>
+            <munit:enable-flow-source value="tbaAggregatorListenerFlow"/>
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <set-variable variableName="result" value="NOT_COMPLETE"/>
+            <aggregators:size-based-aggregator name="sba"  maxSize="1">
+                <aggregators:content>#['testPayload']</aggregators:content>
+                <aggregators:aggregation-complete>
+                    <set-variable variableName="result" value="COMPLETE"/>
+                </aggregators:aggregation-complete>
+            </aggregators:size-based-aggregator>
+
+            <munit-tools:assert-that expression="#[vars.result]" is="#[MunitTools::equalTo('COMPLETE')]"/>
+            <!-- restart! -->
+            <set-payload value="#[java!org::mule::extension::aggregator::munit::AggregatorTestUtils::restartAggregatorWithoutDispose(payload, app.registry['aggregators.aggregatorManager'], app.registry['_muleConfigurationComponentLocator'], 'unregisterAggregatorListenerWhenRestarting/route/1/processors/1')]"/>
+            <set-payload value="#[java!org::mule::extension::aggregator::munit::AggregatorTestUtils::restartAggregatorWithoutDispose(payload, app.registry['aggregators.aggregatorManager'], app.registry['_muleConfigurationComponentLocator'], 'tbaAggregatorListenerFlow/source')]"/>
+
+        </munit:execution>
+    </munit:test>
+
+    <flow name="tbaAggregatorListenerFlow">
+        <aggregators:aggregator-listener aggregatorName="sba"/>
+
+        <logger level="WARN" message="tbaAggregatorListenerFlow"/>
+    </flow>
+
     <!--  -->
     <!-- Migrated from mule-ee-distributions -->
     <!-- https://github.com/mulesoft/mule-ee-distributions/blob/eebf8f83189a0666bc5e36da849aa4c0c0e41fa1/tests/src/test/java/com/mulesoft/mule/distributions/server/AggregatorsTestCase.java#L126 -->

--- a/src/test/munit/aggregators-restart-without-dispose-test-case.xml
+++ b/src/test/munit/aggregators-restart-without-dispose-test-case.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns:aggregators="http://www.mulesoft.org/schema/mule/aggregators"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+                          http://www.mulesoft.org/schema/mule/aggregators http://www.mulesoft.org/schema/mule/aggregators/current/mule-aggregators.xsd
+                          http://www.mulesoft.org/schema/mule/munit-tools http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+                          http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd">
+
+    <configuration-properties file="test.properties"/>
+
+    <munit:config name="aggregators-restart"/>
+
+    <munit:test name="unregisterAggregatorListenerWhenRestarting"
+                tags="Aggregators Extension"
+                description="Unregister Aggregator Listener When Restarting">
+        <munit:enable-flow-sources>
+            <munit:enable-flow-source value="sbalAggregatorListenerFlow"/>
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <set-variable variableName="result" value="NOT_COMPLETE"/>
+            <aggregators:size-based-aggregator name="sbal"  maxSize="1">
+                <aggregators:content>#['testPayload']</aggregators:content>
+                <aggregators:aggregation-complete>
+                    <set-variable variableName="result" value="COMPLETE"/>
+                </aggregators:aggregation-complete>
+            </aggregators:size-based-aggregator>
+
+            <munit-tools:assert-that expression="#[vars.result]" is="#[MunitTools::equalTo('COMPLETE')]"/>
+            <!-- restart! -->
+            <set-payload value="#[java!org::mule::extension::aggregator::munit::AggregatorTestUtils::restartAggregatorWithoutDispose(payload, app.registry['aggregators.aggregatorManager'], app.registry['_muleConfigurationComponentLocator'], 'sbalAggregatorListenerFlow/source')]"/>
+
+        </munit:execution>
+    </munit:test>
+
+    <flow name="sbalAggregatorListenerFlow">
+        <aggregators:aggregator-listener aggregatorName="sbal"/>
+
+        <logger level="DEBUG" message="sbalAggregatorListenerFlow"/>
+    </flow>
+
+</mule>

--- a/src/test/munit/aggregators-restart-without-dispose-test-case.xml
+++ b/src/test/munit/aggregators-restart-without-dispose-test-case.xml
@@ -11,7 +11,7 @@
 
     <configuration-properties file="test.properties"/>
 
-    <munit:config name="aggregators-restart"/>
+    <munit:config name="aggregators-restart-without-dispose"/>
 
     <munit:test name="unregisterAggregatorListenerWhenRestarting"
                 tags="Aggregators Extension"


### PR DESCRIPTION
When stopping the an aggregator listener, the listener previously registered at the start is not unregistered.
